### PR TITLE
HF-98: 리뷰 api 작성

### DIFF
--- a/gible/src/api/review/getAllReview.js
+++ b/gible/src/api/review/getAllReview.js
@@ -1,0 +1,24 @@
+import apiClient from "@/api/axios"
+
+const getAllReview = () => {
+    try{
+        const response = apiClient.get('/review');
+        console.log('response',response)
+
+        if(response.status === 200){
+            return {
+                statusCode : response.status,
+                data : response.data
+            }
+        }
+    }
+    catch(error){
+        return {
+            statusCode : error.response.status
+        }
+    }
+        
+
+}
+
+export default getAllReview

--- a/gible/src/api/review/getReview.js
+++ b/gible/src/api/review/getReview.js
@@ -1,0 +1,21 @@
+import apiClient from "../axios"
+
+const getReview = (reviewId) => {
+    try{
+        const response = apiClient.get(`/${reviewId}`);
+
+        if(response.status === 200){
+            return {
+                statusCode : response.status,
+                data : response.data
+            }
+        }
+    } catch(error){
+        return {
+            statusCode : error.response.status
+        }
+    }
+
+}
+
+export default getReview

--- a/gible/src/api/review/newReview.js
+++ b/gible/src/api/review/newReview.js
@@ -1,0 +1,28 @@
+import { getAuthAxios } from "../authAxios"
+
+const newReview = (formData) => {
+    /*
+        해당 함수 호출 컴포넌트에서 new FormData() 후 formdata에 appned해서 파일및 제목, 내용 업로드 필요
+    */
+    try{
+        const authAxios = getAuthAxios();
+        
+        const response = authAxios.post('/review/upload', formData,{
+            headers : {'Content-type' : 'multipart/form-data', charset : 'utf-8'}
+        })
+
+        if(response.status === 200){
+            return {
+                statusCode : response.status,
+                data : response.data
+            }
+        }
+
+    } catch(error) {
+        return {
+            statusCode : error.response.status
+        }
+    }
+}
+
+export default newReview


### PR DESCRIPTION
## 개요
리뷰 api 작성 - 리뷰 목록 조회, 리뷰 조회, 리뷰 작성

## 구현
- 리뷰 목록 조회 `getAllReview()`
- 리뷰 조회 `getReview()`
- 리뷰 작성 `newReview()`

## 기타
- 리뷰 작성 페이지에서 `FormData()`를 활용해 formData에 이미지를 넣어서 보내줘야합니다. - 참고 : https://eastash.me/http-multipartform-data-feat-react-express-multer#heading-0