### PR TITLE
HF-65: 마이페이지 api 생성

### DIFF
--- a/gible/src/api/mypage/getDelivery.js
+++ b/gible/src/api/mypage/getDelivery.js
@@ -1,0 +1,21 @@
+import apiClient from "../axios";
+
+const getDelivery = () => {
+  try {
+    const response = apiClient.get("/user/delivery");
+    console.log("response", response);
+
+    if (response.status === 200) {
+      return {
+        statusCode: response.status,
+        cata: response.data,
+      };
+    }
+  } catch (error) {
+    return {
+      statusCode: error.response.status,
+    };
+  }
+};
+
+export default getDelivery;

--- a/gible/src/api/mypage/getMyPage.js
+++ b/gible/src/api/mypage/getMyPage.js
@@ -1,0 +1,21 @@
+import apiClient from "../axios";
+
+const getMyPage = () => {
+  try {
+    const response = apiClient.get("/user");
+    console.log("response", response);
+
+    if (response.status === 200) {
+      return {
+        statusCode: response.status,
+        data: response.data,
+      };
+    }
+  } catch (error) {
+    return {
+      statusCode: error.response.status,
+    };
+  }
+};
+
+export default getMyPage;

--- a/gible/src/api/mypage/getMyPosts.js
+++ b/gible/src/api/mypage/getMyPosts.js
@@ -1,0 +1,21 @@
+import apiClient from "../axios";
+
+const getMyPosts = () => {
+  try {
+    const response = apiClient.get("/user/posts");
+    console.log("response", response);
+
+    if (response.status === 200) {
+      return {
+        statusCode: response.status,
+        data: response.data,
+      };
+    }
+  } catch (error) {
+    return {
+      statusCode: error.response.status,
+    };
+  }
+};
+
+export default getMyPosts;

--- a/gible/src/api/mypage/getParticipation.js
+++ b/gible/src/api/mypage/getParticipation.js
@@ -1,0 +1,21 @@
+import apiClient from "../axios";
+
+const getParticipation = () => {
+  try {
+    const response = apiClient.get("/user/participation-event");
+    console.log("response", response);
+
+    if (response.status === 200) {
+      return {
+        statusCode: response.status,
+        data: response.data,
+      };
+    }
+  } catch (error) {
+    return {
+      statusCode: error.response.status,
+    };
+  }
+};
+
+export default getParticipation;


### PR DESCRIPTION
### 개요
마이페이지 API 작성

### 구현 내용
- 마이페이지 조회 `getMyPage()`
- 배송 조회 `getDelivery()`
- 참여 이벤트 조회 `getParticipation()`
- 본인이 작성한 게시물 불러오기 `getMyPosts()`